### PR TITLE
3 progress bar not completing despite process completion

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -104,7 +104,6 @@ public class MainForm : Form {
     {
         if (sub != null)
         {
-            MessageBox.Show($"{sub.Title}");
     
             await Task.Run(() =>
             {
@@ -166,12 +165,24 @@ public class MainForm : Form {
     
                 // Set progress bar to 100% when process completes
                 progressBar.Invoke((MethodInvoker)(() => progressBar.Value = 100));
+                
+                MessageBox.Show("Embedding Done");
+                // Reset all fields after completion
+                this.Invoke((MethodInvoker)(() => ResetFields()));
             });
         }
         else
         {
             MessageBox.Show("Null Sub");
         }
+    }
+
+    private void ResetFields()
+    {
+        txtVideoPath.Text = string.Empty;
+        ddSubtitles.Items.Clear();
+        ddSubtitles.Text = string.Empty;
+        progressBar.Value = 0;
     }
     
     private void UpdateProgressBar(string data)

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -164,6 +164,8 @@ public class MainForm : Form {
                     Console.WriteLine("Processo ffmpeg forçado a encerrar devido ao timeout.");
                 }
     
+                // Set progress bar to 100% when process completes
+                progressBar.Invoke((MethodInvoker)(() => progressBar.Value = 100));
             });
         }
         else

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -126,7 +126,7 @@ public class MainForm : Form {
                 cmd.StartInfo.ArgumentList.Add("balanced");
                 cmd.StartInfo.ArgumentList.Add("-c:a");
                 cmd.StartInfo.ArgumentList.Add("copy");
-                cmd.StartInfo.ArgumentList.Add(Path.Combine(Path.GetDirectoryName(filePath), Path.GetFileNameWithoutExtension(filePath) + "_Legendado.mp4"));
+                cmd.StartInfo.ArgumentList.Add(Path.Combine(Path.GetDirectoryName(filePath), Path.GetFileNameWithoutExtension(filePath) + "_Legendado.mkv"));
                 cmd.StartInfo.UseShellExecute = false;
                 cmd.StartInfo.CreateNoWindow = true;
                 cmd.StartInfo.RedirectStandardError = true;


### PR DESCRIPTION
This pull request includes several updates to the `MainForm.cs` file to enhance the functionality and user experience of the subtitle embedding feature. The most important changes include removing an unnecessary message box, changing the output file extension, adding user feedback upon completion, and resetting form fields.

Enhancements to user experience:

* Removed the message box that displayed the subtitle title when embedding starts. (`MainForm.cs`)
* Changed the output file extension from `.mp4` to `.mkv` for the embedded subtitle file. (`MainForm.cs`)
* Added a message box to notify the user when the embedding process is complete and set the progress bar to 100%. (`MainForm.cs`)
* Implemented a `ResetFields` method to clear input fields and reset the progress bar after the embedding process is completed. (`MainForm.cs`)